### PR TITLE
Add 2019 Web4All hackathon notes

### DIFF
--- a/meeting-minutes/2019-web4all-hackathon/hackathon-resources.md
+++ b/meeting-minutes/2019-web4all-hackathon/hackathon-resources.md
@@ -1,0 +1,23 @@
+Per request in [jupyter/accessibility #2](https://github.com/jupyter/accessibility/issues/2), 
+these notes help keep track of the work done on JupyterLab during 
+the [2019 Web4All hackathon](http://www.w4a.info/2019/hackathon/). 
+These notes are not comprehensive, but they do focus on content 
+created during the hackathon that is not yet tracked elsewhere on 
+[jupyterlab/jupyterlab](https://github.com/jupyterlab/jupyterlab/), 
+[jupyterlab/lumino](https://github.com/jupyterlab/lumino/), or 
+[jupyter/accessibility](https://github.com/jupyter/accessibility/).
+
+During the hackathon, work was done in the forked repo 
+[diagram-codesprint/jupyterlab](https://github.com/diagram-codesprint/jupyterlab)
+and [phosphorjs/phosphor](https://github.com/phosphorjs/phosphor).
+
+Most issues transferred to [jupyterlab/jupyterlab](https://github.com/jupyterlab/jupyterlab/)
+can be [found here](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aissue+author%3Aclapierre+label%3Atag%3AAccessibility+)
+
+Unique issues and PRs not tracked elsewhere include:
+- [diagram-codesprint/jupyterlab #1](https://github.com/diagram-codesprint/jupyterlab/issues/1)
+- [diagram-codesprint/jupyterlab #2](https://github.com/diagram-codesprint/jupyterlab/issues/2)
+- [diagram-codesprint/jupyterlab #4](https://github.com/diagram-codesprint/jupyterlab/pull/4)
+- [diagram-codesprint/jupyterlab #7](https://github.com/diagram-codesprint/jupyterlab/pull/7)
+- [diagram-codesprint/jupyterlab #11](https://github.com/diagram-codesprint/jupyterlab/pull/11)
+


### PR DESCRIPTION
Per request at #2, these notes summarize and record some of the otherwise untracked work done during the 2019 Web4All hackathon. Issues not noted here have already been tracked in jupyterlab/lumino or jupyterlab/jupyterlab.

Fixes #2.

Thanks for reviewing this PR!