### PR TITLE
Edit readme for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,27 @@ Welcome to the Github repository for the accessibility working group of [Project
 
 To be clear, as of March 2019 this software is not accessible. Significant work will be required to reach that goal.
 
-[**Check out the accessibility section of the community forum**](https://discourse.jupyter.org/c/special-topics/accessibility) for  
-ongoing conversations and brainstorms around accessibility in the Jupyter ecosystem.
+If you are trying to use Jupyter tools with assistive technology now, you may be able to get basic support with the following:
+- [Jupyter Notebook a11y toolbar](https://github.com/uclixnjupyternbaccessibility/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/accessibility_toolbar) (from Microsoft research)
+- Make cells editable with a screen reader using the [NVDA Browser Nav add-on](https://addons.nvda-project.org/addons/browsernav.en.html#:~:text=BrowserNav%20addon%20for%20NVDA,comments%20or%20malformed%20HTML%20tables.”)
 
-[**Join our JupyterLab accessibility meetings from the community calendar**](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-community-meetings)
+## Get involved
 
-## Working Group Members
+### Join the conversation
 
-Once we have assembled the working group, we will list the members here.
+- [Check out the accessibility section of the community forum](https://discourse.jupyter.org/c/special-topics/accessibility) for ongoing conversations and brainstorms around accessibility in the Jupyter ecosystem.
+- [Jupyter Notebook Accessibility Issues](https://github.com/jupyter/notebook/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility)
+- [JupyterHub Accessibility Issues](https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aopen+is%3Aissue+label%3Aaccessibility)
+- [JupyterLab Accessibility Issues](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility)
+- If you find something that you think should be labeled for accessibility, feel free to label it or add a comment.
+
+### Join our JupyterLab accessibility meetings
+
+Anyone is welcome to attend, if they would like to discuss a topic or just to listen in.
+
+- When: every other Wednesday (check the [community calendar](https://jupyter.readthedocs.io/en/latest/community/content-community.html#jupyter-community-meetings)) at [10:15 AM Pacific Time](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco&)
+- Where: [`jovyan` Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
+- What: [current agenda](https://hackmd.io/WnaWXboXSiGoqWvev_fAvA) and [public notes](https://github.com/jupyterlab/team-compass/issues/98) from past meetings.
 
 ## Links to accessibility standards and resources
 
@@ -26,29 +39,3 @@ One of our goals is to collect information about accessibility and create docume
 *   [18F Accessibility Guide](https://accessibility.18f.gov/)
 *   [The tota11y toolbar](https://khan.github.io/tota11y/) is a lightweight javascript toolbar for quick a11y analysis.
 *   [The WAVE tool](http://wave.webaim.org/report#/http://z2jh.jupyter.org/) is a web analyzer for page accessibility.
-
-## Links to Jupyter a11y tech
-
-*   [Jupyter Notebook a11y toolbar](https://github.com/uclixnjupyternbaccessibility/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/accessibility_toolbar) (from Microsoft research)
-
-## Links to accessibility related issues on GitHub
-
-A number of open issue related to accessibility are already open on the repos above. Please help us to aggregate links to those here. The preferred way to do this is for each repo to have a unique GitHub label for accessibility, and then to link to the GitHub issue search that automatically lists those issues:
-
-*   [Jupyter Notebook Accessibility Issues](https://github.com/jupyter/notebook/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility)
-*   [JupyterHub Accessibility Issues](https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aopen+is%3Aissue+label%3Aaccessibility)
-*   [JupyterLab Accessibility Issues](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility)
-
-If there are additional issues we are missing, please help us by tagging them or listing them here.
-
-### Bi-Weekly Meeting
-
-We have videoconference meetings every other week where we discuss what we have been working on and get feedback from one another.
-
-Anyone is welcome to attend, if they would like to discuss a topic or just to listen in.
-
-- When: Wednesdays [10:15 AM Pacific Time](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco&)
-- Where: [`jovyan` Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
-- What: [Meeting notes](https://hackmd.io/WnaWXboXSiGoqWvev_fAvA)
-- [Public notes](https://github.com/jupyterlab/team-compass/issues/98)
-- [Jupyter Calendar](https://calendar.google.com/calendar/u/0/r?cid=dgpd36f43et9grabn6tdin6pmc@group.calendar.google.com&cid=m3hek69dag7381umt8kcjd75u4@group.calendar.google.com&cid=aqpkui5q7oi32pk9tcp53hnssc@group.calendar.google.com&cid=d1874ur6fdhuj0snjnilac2nlc@group.calendar.google.com&cid=piahinejjr6ssvi8ikmjjop6ro@group.calendar.google.com)


### PR DESCRIPTION
In a previous JupyterLab accessibility meeting, we received feedback that some new attendees had trouble finding the meeting and that even when they found this repo's read me, it was unclear when the event was happening. 

This PR adds edits that bring ways people can act on accessibility work (such as joining the meeting) earlier on the list. It then reorganizes the rest of the content to have it make sense. 

I also removed the working group section since none have been formed and I would rather encourage everyone to join. 