### PR TITLE
Add roadmap to keep people up to date on CZI grant work

### DIFF
--- a/docs/source/meeting-minutes/czi-grant-updates/czi-grant-roadmap.md
+++ b/docs/source/meeting-minutes/czi-grant-updates/czi-grant-roadmap.md
@@ -1,0 +1,72 @@
+# Jupyter Accessibility Roadmap
+
+Created on: November 11, 2021
+
+Last updated on: December 8, 2021
+
+## Primary goals
+
+This roadmap is meant to communicate accessibility efforts funded by the [CZI EOSS grant Inclusive and Accessible Computing in the Jupyter Ecosystem](https://chanzuckerberg.com/eoss/proposals/inclusive-and-accessible-scientific-computing-in-the-jupyter-ecosystem/), work previously discussed on this and more project-specific repositories.
+
+Over the course of the two-year grant, we are aiming to transform the Jupyter ecosystem in four ways:
+
+1. Make JupyterLab accessible (with an emphasis on [Web Content Accessibility Guidelines](https://en.wikipedia.org/wiki/Web_Content_Accessibility_Guidelines)) 
+2. Build automated accessibility tests that are compatible with Jupyter tools
+3. Document what we've learn/best practices for accessibility specific to Jupyter or the wider scientific Python ecosystem
+4. Share work with other projects and help them start implementing accessibility fixes when possible
+
+## Action items
+
+### In the works
+
+- Add automated accessibility tests to JupyterLab ([JupyterLab issue #9742](https://github.com/jupyterlab/jupyterlab/issues/9742))
+- Update the [JupyterLab accessibility project board](https://github.com/orgs/Quansight-Labs/projects/5/views/1)
+- Determine pathways for inviting community engagement
+
+### Coming soon
+
+- Improve color contrast in JupyterLab ([WCAG minimum contrast](https://www.w3.org/TR/WCAG21/#contrast-minimum)) ([JupyterLab issue #8832](https://github.com/jupyterlab/jupyterlab/issues/8832))
+- Support for 400% zoom in JupyterLab ([WCAG reflow](https://www.w3.org/TR/WCAG21/#reflow))([JupyterLab issue #10004](https://github.com/jupyterlab/jupyterlab/issues/10004))
+- Cross-project outreach within Project Jupyter and beyond
+- Add a news section to the [jupyter-a11y-mgmt team compass](https://quansight-labs.github.io/jupyter-a11y-mgmt/readme.html)
+
+### Not too far off
+
+- Support full-interface keyboard navigability in JupyterLab ([WCAG](https://www.w3.org/TR/WCAG21/#keyboard-accessible))
+- JupyterLab documentation accessibility audit (manual and automated tests)
+- Update JupyterLab documentation to cover accessibility features added to JupyterLab
+- Update JupyterLab contributing guidelines to include accessibility considerations
+
+### All roadmap items
+
+The above items show what we'll be working on in the near future, not everything on the roadmap. If you want to review the full scope of the two-year grant, all key items are listed on the [jupyter-a11y-mgmt repository's planning issues](https://github.com/orgs/Quansight-Labs/projects/5/views/1). 
+
+This work will happen across Jupyter projects-- with a focus on JupyterLab in the first year-- and in wider projects from the scientific Python ecosystem where possible. A large effort will be changes to software, automated tests, and documentation. 
+
+---
+
+## What is this?
+
+Welcome! You've found your way to the public roadmap for Jupyter accessibility efforts that fall in scope of the [CZI EOSS grant Inclusive and Accessible Computing in the Jupyter Ecosystem](https://chanzuckerberg.com/eoss/proposals/inclusive-and-accessible-scientific-computing-in-the-jupyter-ecosystem/).
+
+This roadmap's content is derived from
+- [The original grant proposal](https://github.com/jupyter/accessibility/blob/master/grant-applications/Inclusive_and_Accessible_Scientific_Computing_in_Jupyter_Ecosystem_SUBMITTED_PROPOSAL.pdf)
+- The [jupyter-a11y-mgmt repository's planning issues](https://github.com/orgs/Quansight-Labs/projects/5/views/1) 
+- The [JupyterLab accessibility project board](https://github.com/orgs/Quansight-Labs/projects/5/views/1)
+- Feedback from community members working on accessibility
+
+## Join in
+
+### Contribute
+
+Does one of the above items interest you? Do you have accessibility knowledge that you'd like to share? This work takes place across multiple open-source projects and repositories, so [jupyter-a11y-mgmt's contributing guide](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/blob/main/CONTRIBUTING.md) might be a good place to start.
+
+### Stay up to date 
+
+This roadmap will be updated periodically. Check back to find what's been completed and what's to be worked on next.
+
+Tasks that have been completed will be listed on the changelog (🚧 coming soon!)
+
+### Start learning about accessibility
+
+🚧 Coming soon!


### PR DESCRIPTION
Since the CZI grant process has been on this repo in the past, I thought it'd make sense to share roadmap we're using to organize all the issues across project repos and make it clearer for the community that they can join in.

I've opened this PR as a draft because I want to give this another pass when I'm less sleepy before merging. Some other changes I need to make:
- [ ] Create a file to listed completed roadmap items (also good so people can double check that changes are working)
- [ ] Check if I need to update the docs index (or if this is grouped in fine with the meeting notes)
- [ ] Make sure the intro has proper context for this repository. Maybe link to the proposal or other issues on this repo that are relevant.
- [ ] Link to this from the readme