### PR TITLE
Add last month of JLab accessibility meeting notes 

### DIFF
--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-06-16.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-06-16.md
@@ -1,6 +1,8 @@
-## 06.16.21
+## 06.16.21 Meeting Minutes 
+
 ### Attendees
 - Oops! No one signed in.
+
 ### What are people working on?
 - Isabela
     - [#10146](https://github.com/jupyterlab/jupyterlab/pull/10146) was merged! This made some color contrast fixes to the filebrowser and command palette. 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-06-30.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-06-30.md
@@ -1,4 +1,4 @@
-## 06.30.21
+## 06.30.21 Meeting Minutes 
 ### Attendees
 - Mike
 - Tony Fast - Quansight

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-07-14.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-07-14.md
@@ -1,4 +1,5 @@
-## 07.14.21
+## 07.14.21 Meeting Minutes 
+
 ### Attendees
 - Darian
 - Tony

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-07-28.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-07-28.md
@@ -1,4 +1,5 @@
-## 07.28.21
+## 07.28.21 Meeting Minutes 
+
 ### Attendees
 - Tony
 - Isabela

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-08-11.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-08-11.md
@@ -1,4 +1,5 @@
-## 08.11.21
+## 08.11.21 Meeting Minutes 
+
 ### Attendees
 * Martha
 * Isabela

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-08-25.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-08-25.md
@@ -1,4 +1,5 @@
-## 08.25.21
+## 08.25.21 Meeting Minutes 
+
 ### Attendees
 - Nick
 - Martha

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-09-08.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-09-08.md
@@ -1,4 +1,5 @@
-## 09.08.21
+## 09.08.21 Meeting Minutes 
+
 ### Attendees
 - Jason
 - Isabela

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-09-22.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-09-22.md
@@ -1,4 +1,5 @@
-## 09.22.21
+## 09.22.21 Meeting Minutes 
+
 ### Attendees
 - Martha
 - Mike

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-10-06.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-10-06.md
@@ -1,4 +1,5 @@
-## 10.6.21
+## 10.6.21 Meeting Minutes 
+
 ### Attendees
 - Jason
 - Tony

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-10-20.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-10-20.md
@@ -1,4 +1,5 @@
-## 10.20.21
+## 10.20.21 Meeting Minutes 
+
 ### Attendees
 - Tony
 - Jessica

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-03.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-03.md
@@ -1,4 +1,4 @@
-## 11.03.21
+## 11.03.21 Meeting Minutes
 
 ### Attendees
 - Jason

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-17.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-17.md
@@ -1,4 +1,4 @@
-## 11.17.21
+## 11.17.21 Meeting Minutes 
 
 ### Attendees
 - Martha

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-12-01.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-12-01.md
@@ -1,4 +1,4 @@
-## 12.01.21
+## 12.01.21 Meeting Minutes 
 
 ### Attendees
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-12-15.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-12-15.md
@@ -1,4 +1,4 @@
- ## 12.15.21
+ ## 12.15.21 Meeting Minutes 
 
 ### Attendees
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-01-12.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-01-12.md
@@ -1,4 +1,4 @@
-## 1.12.22
+## 1.12.22 Meeting Minutes 
 
 ### Attendees
 - tony

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-01-26.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-01-26.md
@@ -1,4 +1,4 @@
-## 1.26.22
+## 1.26.22 Meeting Minutes 
 
 ### Attendees
 - Isabela

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-02-09.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-02-09.md
@@ -1,6 +1,6 @@
-## 2.09.22
+## 2.09.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Nick
 - Tony
 - Martha
@@ -10,7 +10,7 @@
 - Chadi
 - Isabela
 
-## What are people working on
+### What are people working on
 
 - Chadi
     - Interest in being assigned from existing issues

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-02-23.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-02-23.md
@@ -1,6 +1,6 @@
-## 2.23.22
+## 2.23.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Tony
 - Ely
 - Gabriel
@@ -8,7 +8,7 @@
 - Nick
 - Jason
 
-## notes
+### notes
 
 * pdf accessibility https://www.section508.gov/create/pdfs/
 * stylelint-a11y https://github.com/YozhikM/stylelint-a11y
@@ -17,7 +17,7 @@
     * should we talk to people who are used to customizing colors?
     * an export button would be really good for someone who has spent a lot of time working on their own theme locally 
 
-## What are people working on
+### What are people working on
 
 * @tonyfast
     * reusable tasks for building jupyterlab, retrolab, lumino combinations.

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-03-09.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-03-09.md
@@ -1,6 +1,6 @@
-## 3.9.22
+## 3.9.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Martha
 - Tony
 - Jason W
@@ -8,7 +8,7 @@
 - Isabela
 - Gabriel
 
-## Agenda
+### Agenda
 - Gabriel
     - What do developers want/what would you all find helpful in the [jupyter/accessibility repo](https://github.com/jupyter/accessibility)
         - - People can give feedback and ideas later via issues (or PRs if you have something you want to contribute) on jupyter/accessibility.

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-03-23.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-03-23.md
@@ -1,6 +1,6 @@
-## 3.23.22
+## 3.23.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Mike
 - Ely
@@ -10,7 +10,7 @@
 - Tania
 - Isabela
 
-## Agenda
+### Agenda
 
 Jupyter accessibility workshop resources! (First two events are up, but the last ones are pending. They will all link here.) [Jupyter accessibility workshops repo](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/tree/main/events)
 
@@ -31,7 +31,7 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
     - Same but for continued vote/existence?
 - Pros and cons of each level. Summary is that it seems like there's more pros and no real cons on being a software project (long term). 
 
-## Next steps
+### Next steps
 
 - **TODO**: open an issue on jupyter/accessibility and use it as a RFD (request for discussion)/lazy voting and revisit in 2-4 weeks?
 - Isabela to follow up with Mike on asking the community for feedback on existing accessibility fixes.

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-06.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-06.md
@@ -1,0 +1,54 @@
+## 4.6.22
+
+## Attendees
+
+- Frederic
+- Nick
+- Jason
+- Darian
+- Martha
+- Ely
+- Gabriel
+- Mike
+- Preston
+- Tom
+- Rohit
+- Pooja
+- Isabela
+
+## What are people working on?
+
+- Preston
+    - Contributing guide questions https://github.com/jupyter/accessibility/issues/47
+    - Should this be specific to the repo (not general jupyter contrib)
+    - CI. what's the status (based on jupyterlab benchmarks repo)
+    - things that don't exist (another issue or what's happening?)
+    - Follow up on issue with some of these specifics.
+
+- Tom
+    - Has there been a date announced for when support for classic Notebook (as it is now) ends? This has to do with Notebook 7 release work.
+    - goal is to only support two versions simultaneously
+    - nbclassic package (notebook 6 ui written as jupyter server extension)
+    - https://github.com/jupyter/notebook-team-compass/issues/5#issuecomment-1085254000
+    - support for extension updates is a priority
+
+- Gabriel
+    - :tada: Not much to discuss, but I put up my first JupyterLab PR: [Add checkboxes to file browser #12299](https://github.com/jupyterlab/jupyterlab/pull/12299). 
+        - Small accessibility win; hopefully will lead to more
+
+- Darian
+    - Governance question re: [Working Group and Subproject brought up by Tania](https://github.com/jupyter/governance/issues/124)
+
+- Isabela
+    - Open question from me, what do you all want me to work on next?
+        - From notebook call: nbgrader importance; could use my attention
+        - "It just can't be worse than the existing nbgrader" :laughing: 
+    - If nothing else, can we go through the [JupyterLab accessibility project board?](https://github.com/orgs/jupyterlab/projects/1)
+    - tag people not necessarily accessibility involved if they know what's up
+    - ask it in jupyterlab 
+
+## Next steps
+
+- Follow up on accessibility fixes survey/feedback request (Isabela to Mike)
+- Follow up with Tania about last meeting's governance discussion (Isabela to Tania)
+- Three options for governance next steps and have people involved come to consensus (Isabela to create and tag people)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-06.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-06.md
@@ -1,6 +1,6 @@
-## 4.6.22
+## 4.6.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Frederic
 - Nick
@@ -16,7 +16,7 @@
 - Pooja
 - Isabela
 
-## What are people working on?
+### What are people working on?
 
 - Preston
     - Contributing guide questions https://github.com/jupyter/accessibility/issues/47
@@ -47,7 +47,7 @@
     - tag people not necessarily accessibility involved if they know what's up
     - ask it in jupyterlab 
 
-## Next steps
+### Next steps
 
 - Follow up on accessibility fixes survey/feedback request (Isabela to Mike)
 - Follow up with Tania about last meeting's governance discussion (Isabela to Tania)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-20.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-20.md
@@ -1,0 +1,41 @@
+## 4.20.22
+
+## Attendees
+
+- Gabriel F.
+- Nick
+- Isabela
+
+## What are people working on?
+
+- Please vote on [jupyter/accessibility's status in the new Jupyter governance](https://github.com/jupyter/accessibility/issues/81) by midnight wherever you are today!
+
+- Meeting this Friday, April 22: FAST-based JupyterLab UI toolkit. This is a discussion around [the proposal for a new JupyterLab UI toolkit](https://github.com/jupyterlab/team-compass/issues/143), which we've seen demo'ed for accessibility considerations. Show up or comment on the issue if you'd like to weigh in!
+
+- Isabela
+    - [isabela-pf/a11y-events Brainstorm list of event ideas](https://github.com/isabela-pf/a11y-events/issues/4)
+    - [Scoping automated testing steps](https://docs.google.com/spreadsheets/d/1mUmZevaEI1HwZQ0uF5Rjhb9mGEJ71RAkjj-Lxr3sLZw/edit?usp=sharing)
+
+- Gabriel
+    - A [plan for the next six weeks](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/97) that Quansight Labs is considering
+        - A number of learnings about **automated accessibility tests** has been rolled into that doc
+    - We are looking for pathways to contributions from other people - especially in this group
+
+- Nick
+    - [Model-based testing](https://en.wikipedia.org/wiki/Model-based_testing). Build a user model of somebody using the Jupyter test. A model is more interesting that a particular case because you get to weird error messages and corner cases that we need to test for.
+    - [A close example with stateful, property-based testing in Hypothesis](https://hypothesis.readthedocs.io/en/latest/stateful.html)
+    - Workflow is not to do this all thinking about it as a test, but more as a state and task combo (ie. I'm looking at a notebook and I want to )
+
+- on the subject of building up a language to create test plans (Isabela metaphor: magnetic fridge poetry)
+    - https://github.com/deathbeds/jupyterlab-outsource
+    - https://pypi.org/project/jupyterlite-robotkernel
+    - goal, action, goal, action, goal action (that's a human-readable way we can work with)
+    - https://github.com/robots-from-jupyter/robotframework-jupyterlibrary
+    - https://pypi.org/project/robot-axelibrary/
+    - https://github.com/ipython/traitlets/pull/705#issuecomment-1103958033
+
+- opt-in a11y checks - label on PR that goes into changelog
+
+- https://github.com/jupyterlab/maintainer-tools
+- https://github.com/jupyter-server/jupyter_releaser
+- https://pv.github.io/numpy-bench/

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-20.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-04-20.md
@@ -1,12 +1,12 @@
-## 4.20.22
+## 4.20.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Gabriel F.
 - Nick
 - Isabela
 
-## What are people working on?
+### What are people working on?
 
 - Please vote on [jupyter/accessibility's status in the new Jupyter governance](https://github.com/jupyter/accessibility/issues/81) by midnight wherever you are today!
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-04.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-04.md
@@ -1,0 +1,20 @@
+## 5.04.22
+
+## Attendees
+
+- Martha
+- Isabela
+- Gabriel
+
+## What are people working on?
+
+- Isabela
+    - Governance follow up. We voted at [jupyter/accessibility #81](https://github.com/jupyter/accessibility/issues/81). Isabela needs to know how to move this forward.
+    - Testing updates! We're at the foundation level now, but thoughts on prioirities are welcome.
+        - Feedback: documentation is the most valuable thing! 
+        - Mentioned links: [Quansight-Labs/jupyter-a11y-mgmt #95 Scoping automated testing comment](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/95#issuecomment-1112427588) and [jupyter/accessibility #74 past draft PR for axe-core testing](https://github.com/jupyter/accessibility/pull/74).
+
+## Next steps
+
+- The dream: updated galata documentation.😊
+- Follow up about governance status (Isabela)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-04.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-04.md
@@ -1,12 +1,12 @@
-## 5.04.22
+## 5.04.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Martha
 - Isabela
 - Gabriel
 
-## What are people working on?
+### What are people working on?
 
 - Isabela
     - Governance follow up. We voted at [jupyter/accessibility #81](https://github.com/jupyter/accessibility/issues/81). Isabela needs to know how to move this forward.
@@ -14,7 +14,7 @@
         - Feedback: documentation is the most valuable thing! 
         - Mentioned links: [Quansight-Labs/jupyter-a11y-mgmt #95 Scoping automated testing comment](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/95#issuecomment-1112427588) and [jupyter/accessibility #74 past draft PR for axe-core testing](https://github.com/jupyter/accessibility/pull/74).
 
-## Next steps
+### Next steps
 
 - The dream: updated galata documentation.😊
 - Follow up about governance status (Isabela)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-18.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-18.md
@@ -1,10 +1,10 @@
-## 5.18.22
+## 5.18.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Isabela
 - Martha
 
-## What are people working on?
+### What are people working on?
 - jupyter/accessibility is on its way to Subproject status! 🎉 PR is being voted on on [jupyter/governance #129](https://github.com/jupyter/governance/pull/129)
 - jupyter/accessibility automated testing has been updated! Changes are still being made, but there's a lot to show.
     - [jupyter/accessibility #83 Axe Gitpod JupyterLab](https://github.com/jupyter/accessibility/pull/83)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-18.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-05-18.md
@@ -1,0 +1,15 @@
+## 5.18.22
+
+## Attendees
+- Isabela
+- Martha
+
+## What are people working on?
+- jupyter/accessibility is on its way to Subproject status! 🎉 PR is being voted on on [jupyter/governance #129](https://github.com/jupyter/governance/pull/129)
+- jupyter/accessibility automated testing has been updated! Changes are still being made, but there's a lot to show.
+    - [jupyter/accessibility #83 Axe Gitpod JupyterLab](https://github.com/jupyter/accessibility/pull/83)
+    - [jupyter/accessibility #84 Developer tooling for building/testing jupyter artifacts](https://github.com/jupyter/accessibility/pull/84)
+    - Isabela: Draft testing scripts (for new, task-style tests) on [a comment on quansight-labs/jupyter-a11y-mgmt #95](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/95#issuecomment-1118978913)
+    - [More info on axe-core tests]( https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules)
+- Isabela
+    - Learning and contributing event ideas to keep the community energy going. Rough draft agendas on [a series of comments on isabela-pf/a11y-events #4](https://github.com/isabela-pf/a11y-events/issues/4#issuecomment-1124536984) 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -1877,3 +1877,137 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
 
 - **TODO**: open an issue on jupyter/accessibility and use it as a RFD (request for discussion)/lazy voting and revisit in 2-4 weeks?
 - Isabela to follow up with Mike on asking the community for feedback on existing accessibility fixes.
+
+## 4.6.22
+
+## Attendees
+
+- Frederic
+- Nick
+- Jason
+- Darian
+- Martha
+- Ely
+- Gabriel
+- Mike
+- Preston
+- Tom
+- Rohit
+- Pooja
+- Isabela
+
+## What are people working on?
+
+- Preston
+    - Contributing guide questions https://github.com/jupyter/accessibility/issues/47
+    - Should this be specific to the repo (not general jupyter contrib)
+    - CI. what's the status (based on jupyterlab benchmarks repo)
+    - things that don't exist (another issue or what's happening?)
+    - Follow up on issue with some of these specifics.
+
+- Tom
+    - Has there been a date announced for when support for classic Notebook (as it is now) ends? This has to do with Notebook 7 release work.
+    - goal is to only support two versions simultaneously
+    - nbclassic package (notebook 6 ui written as jupyter server extension)
+    - https://github.com/jupyter/notebook-team-compass/issues/5#issuecomment-1085254000
+    - support for extension updates is a priority
+
+- Gabriel
+    - :tada: Not much to discuss, but I put up my first JupyterLab PR: [Add checkboxes to file browser #12299](https://github.com/jupyterlab/jupyterlab/pull/12299). 
+        - Small accessibility win; hopefully will lead to more
+
+- Darian
+    - Governance question re: [Working Group and Subproject brought up by Tania](https://github.com/jupyter/governance/issues/124)
+
+- Isabela
+    - Open question from me, what do you all want me to work on next?
+        - From notebook call: nbgrader importance; could use my attention
+        - "It just can't be worse than the existing nbgrader" :laughing: 
+    - If nothing else, can we go through the [JupyterLab accessibility project board?](https://github.com/orgs/jupyterlab/projects/1)
+    - tag people not necessarily accessibility involved if they know what's up
+    - ask it in jupyterlab 
+
+## Next steps
+
+- Follow up on accessibility fixes survey/feedback request (Isabela to Mike)
+- Follow up with Tania about last meeting's governance discussion (Isabela to Tania)
+- Three options for governance next steps and have people involved come to consensus (Isabela to create and tag people)
+
+## 4.20.22
+
+## Attendees
+
+- Gabriel F.
+- Nick
+- Isabela
+
+## What are people working on?
+
+- Please vote on [jupyter/accessibility's status in the new Jupyter governance](https://github.com/jupyter/accessibility/issues/81) by midnight wherever you are today!
+
+- Meeting this Friday, April 22: FAST-based JupyterLab UI toolkit. This is a discussion around [the proposal for a new JupyterLab UI toolkit](https://github.com/jupyterlab/team-compass/issues/143), which we've seen demo'ed for accessibility considerations. Show up or comment on the issue if you'd like to weigh in!
+
+- Isabela
+    - [isabela-pf/a11y-events Brainstorm list of event ideas](https://github.com/isabela-pf/a11y-events/issues/4)
+    - [Scoping automated testing steps](https://docs.google.com/spreadsheets/d/1mUmZevaEI1HwZQ0uF5Rjhb9mGEJ71RAkjj-Lxr3sLZw/edit?usp=sharing)
+
+- Gabriel
+    - A [plan for the next six weeks](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/97) that Quansight Labs is considering
+        - A number of learnings about **automated accessibility tests** has been rolled into that doc
+    - We are looking for pathways to contributions from other people - especially in this group
+
+- Nick
+    - [Model-based testing](https://en.wikipedia.org/wiki/Model-based_testing). Build a user model of somebody using the Jupyter test. A model is more interesting that a particular case because you get to weird error messages and corner cases that we need to test for.
+    - [A close example with stateful, property-based testing in Hypothesis](https://hypothesis.readthedocs.io/en/latest/stateful.html)
+    - Workflow is not to do this all thinking about it as a test, but more as a state and task combo (ie. I'm looking at a notebook and I want to )
+
+- on the subject of building up a language to create test plans (Isabela metaphor: magnetic fridge poetry)
+    - https://github.com/deathbeds/jupyterlab-outsource
+    - https://pypi.org/project/jupyterlite-robotkernel
+    - goal, action, goal, action, goal action (that's a human-readable way we can work with)
+    - https://github.com/robots-from-jupyter/robotframework-jupyterlibrary
+    - https://pypi.org/project/robot-axelibrary/
+    - https://github.com/ipython/traitlets/pull/705#issuecomment-1103958033
+
+- opt-in a11y checks - label on PR that goes into changelog
+
+- https://github.com/jupyterlab/maintainer-tools
+- https://github.com/jupyter-server/jupyter_releaser
+- https://pv.github.io/numpy-bench/
+
+## 5.04.22
+
+## Attendees
+
+- Martha
+- Isabela
+- Gabriel
+
+## What are people working on?
+
+- Isabela
+    - Governance follow up. We voted at [jupyter/accessibility #81](https://github.com/jupyter/accessibility/issues/81). Isabela needs to know how to move this forward.
+    - Testing updates! We're at the foundation level now, but thoughts on prioirities are welcome.
+        - Feedback: documentation is the most valuable thing! 
+        - Mentioned links: [Quansight-Labs/jupyter-a11y-mgmt #95 Scoping automated testing comment](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/95#issuecomment-1112427588) and [jupyter/accessibility #74 past draft PR for axe-core testing](https://github.com/jupyter/accessibility/pull/74).
+
+## Next steps
+
+- The dream: updated galata documentation.😊
+- Follow up about governance status (Isabela)
+
+## 5.18.22
+
+## Attendees
+- Isabela
+- Martha
+
+## What are people working on?
+- jupyter/accessibility is on its way to Subproject status! 🎉 PR is being voted on on [jupyter/governance #129](https://github.com/jupyter/governance/pull/129)
+- jupyter/accessibility automated testing has been updated! Changes are still being made, but there's a lot to show.
+    - [jupyter/accessibility #83 Axe Gitpod JupyterLab](https://github.com/jupyter/accessibility/pull/83)
+    - [jupyter/accessibility #84 Developer tooling for building/testing jupyter artifacts](https://github.com/jupyter/accessibility/pull/84)
+    - Isabela: Draft testing scripts (for new, task-style tests) on [a comment on quansight-labs/jupyter-a11y-mgmt #95](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/95#issuecomment-1118978913)
+    - [More info on axe-core tests]( https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules)
+- Isabela
+    - Learning and contributing event ideas to keep the community energy going. Rough draft agendas on [a series of comments on isabela-pf/a11y-events #4](https://github.com/isabela-pf/a11y-events/issues/4#issuecomment-1124536984) 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -1216,7 +1216,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Follow up about CodeMirror 6 (Isabela and Kevin)
 - Follow up about accessibility workshop [jupyter/accessibility #43](https://github.com/jupyter/accessibility/issues/43)
 
-## 06.16.21
+## 06.16.21 Meeting Minutes 
 ### Attendees
 - Oops! No one signed in.
 ### What are people working on?
@@ -1229,7 +1229,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Kevin and Cameron
     - Accessibility considerations in RTC commenting? 
 
-## 06.30.21
+## 06.30.21 Meeting Minutes 
 ### Attendees
 - Mike
 - Tony Fast - Quansight
@@ -1264,7 +1264,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Multiple skiplinks to different regions (Isabela to reach out to Jason)
 - Mike is going to look into color stuff? :)
 
-## 07.14.21
+## 07.14.21 Meeting Minutes 
 ### Attendees
 - Darian
 - Tony
@@ -1289,7 +1289,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Test documentation sprint on July 21 (Tony and Isabela) (and anyone else who wants to join!)
 - Review [jupyterlab #8832](https://github.com/jupyterlab/jupyterlab/issues/8832) and [jupyterlab #1008](https://github.com/jupyterlab/jupyterlab/issues/1008) for next steps on color contrast (Isabela)
 
-## 07.28.21
+## 07.28.21 Meeting Minutes 
 ### Attendees
 - Tony
 - Isabela
@@ -1320,7 +1320,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Review [jupyterlab #8832](https://github.com/jupyterlab/jupyterlab/issues/8832) and [jupyterlab #1008](https://github.com/jupyterlab/jupyterlab/issues/1008) for next steps on color contrast (Isabela)
 - Test documentation sprint with NumPy on July 28 (Tony and Isabela) (and anyone else who wants to join!)
 
-## 08.11.21
+## 08.11.21 Meeting Minutes 
 ### Attendees
 * Martha
 * Isabela
@@ -1351,7 +1351,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
       - https://www.w3.org/TR/wai-aria-practices-1.1/#wai-aria-roles-states-and-properties-3
 ### Next steps
 
-## 08.25.21
+## 08.25.21 Meeting Minutes 
 ### Attendees
 - Nick
 - Martha
@@ -1385,7 +1385,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Ask Martha about explaining how accessibility needs to fit in to Jupyter (Isabela)
 - Follow up/finish alt text guide for workshop (Isabela)
 
-## 09.08.21
+## 09.08.21 Meeting Minutes 
 ### Attendees
 - Jason
 - Isabela
@@ -1405,7 +1405,8 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Formal announcement of accessibility workshops (Isabela and Tony)
 - Connect with other community workshop people (Isabela)
 
-## 09.22.21
+## 09.22.21 Meeting Minutes 
+
 ### Attendees
 - Martha
 - Mike
@@ -1430,7 +1431,8 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 ### Next Steps
 - Talk about CodeMirror 6 again at the beginning of October
 
-## 10.6.21
+## 10.6.21 Meeting Minutes 
+
 ### Attendees
 - Jason
 - Tony
@@ -1456,7 +1458,8 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
     -  Kevin is interested in this and would like to work with others.
     -  Martha may also be able to help!
 
-## 10.20.21
+## 10.20.21 Meeting Minutes 
+
 ### Attendees
 - Tony
 - Jessica
@@ -1490,7 +1493,8 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 ### Next Steps
 - Follow up with Jenn about funding (Isabela+)
 
-## 11.03.21
+## 11.03.21 Meeting Minutes 
+
 ### Attendees
 - Jason
 - Martha
@@ -1543,7 +1547,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Frederic will check in with Johan about CodeMirror 6
 - Isabela will update the [JupyterLab accessibility project](https://github.com/orgs/jupyterlab/projects/1) to make sure it's ready for people to pick work off again.
 
-## 11.17.21
+## 11.17.21 Meeting Minutes 
 
 ### Attendees
 - Martha
@@ -1591,7 +1595,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
         - Add another page "changelog" that lists what we have completed when things get moved off the roadmap.
         - Are there repository labels/tags that make sense to link to?
 
-## 12.01.21
+## 12.01.21 Meeting Minutes 
 
 ### Attendees
 
@@ -1629,7 +1633,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
         - [sytlelint-scss/stylelint-scss  Rule idea: color-no-non-variables #4 ](https://github.com/stylelint-scss/stylelint-scss/issues/4)
         - [stylelint documentation's list of rules for color](https://stylelint.io/user-guide/rules/list/#color-1)
 
- ## 12.15.21
+## 12.15.21 Meeting Minutes 
 
 ### Attendees
 
@@ -1663,7 +1667,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
     - [jupyterlab/jupyterlab PR #11658](https://github.com/jupyterlab/jupyterlab/pull/11658) is work on color contrast. I've gotten some review but there's lots to discuss.
     - Roadmap updates (for CZI grant reporting and community communication) based on all your feedback. You can review the PR [Quansight-Labs/jupyter-a11y-mgmt #60](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/pull/60). When we get it cleaned up, it will go to jupyter/accessibility so it's more findable by the community.
 
-    ## 1.12.22
+## 1.12.22 Meeting Minutes 
 
 ### Attendees
 - tony
@@ -1708,7 +1712,7 @@ Some links in chat:
 - https://github.com/Zac-HD/hypothesis-jsonschema
 - https://testguild.com/python-automation-testing/
 
-## 1.26.22
+## 1.26.22 Meeting Minutes 
 
 ### Attendees
 - Isabela
@@ -1744,9 +1748,9 @@ Some links in chat:
 - Follow up on cross-community collaboration (Isabela, Jenn, Tony, Patrick)
 - Remove hardcoded css colors to improve the extensibility of the these (maybe Nick?)
 
-## 2.09.22
+## 2.09.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Nick
 - Tony
 - Martha
@@ -1756,7 +1760,7 @@ Some links in chat:
 - Chadi
 - Isabela
 
-## What are people working on
+### What are people working on
 
 - Chadi
     - Interest in being assigned from existing issues
@@ -1787,9 +1791,9 @@ Some links in chat:
 - Isabela: Jupyter accessibility workshops in March!
     - Draft sprint topic is on auditing. Is there anything specific you'd all like to have covered? Are there any projects you'd like to propose we use for the sprint?
 
-## 2.23.22
+## 2.23.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Tony
 - Ely
 - Gabriel
@@ -1797,7 +1801,7 @@ Some links in chat:
 - Nick
 - Jason
 
-## notes
+### notes
 
 * pdf accessibility https://www.section508.gov/create/pdfs/
 * stylelint-a11y https://github.com/YozhikM/stylelint-a11y
@@ -1806,15 +1810,15 @@ Some links in chat:
     * should we talk to people who are used to customizing colors?
     * an export button would be really good for someone who has spent a lot of time working on their own theme locally 
 
-## What are people working on
+### What are people working on
 
 * @tonyfast
     * reusable tasks for building jupyterlab, retrolab, lumino combinations.
     * turning [`jupyter/accessibility`](https://github.com/jupyter/accessibility) into a js/py packages
 
-## 3.9.22
+## 3.9.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Martha
 - Tony
 - Jason W
@@ -1822,7 +1826,7 @@ Some links in chat:
 - Isabela
 - Gabriel
 
-## Agenda
+### Agenda
 - Gabriel
     - What do developers want/what would you all find helpful in the [jupyter/accessibility repo](https://github.com/jupyter/accessibility)
         - - People can give feedback and ideas later via issues (or PRs if you have something you want to contribute) on jupyter/accessibility.
@@ -1840,9 +1844,9 @@ Some links in chat:
 - Tony 
     - brings up discussion at [matplotlib/matplotlib #15971 Improve the accessibility of figures shown with `_repr_html_`](https://github.com/matplotlib/matplotlib/issues/15971#issuecomment-1062772917) around deprecation of `longdesc` and if there are ways this can be solved in a better experience and not only one-off tags.
 
-## 3.23.22
+## 3.23.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Mike
 - Ely
@@ -1852,7 +1856,7 @@ Some links in chat:
 - Tania
 - Isabela
 
-## Agenda
+### Agenda
 
 Jupyter accessibility workshop resources! (First two events are up, but the last ones are pending. They will all link here.) [Jupyter accessibility workshops repo](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/tree/main/events)
 
@@ -1873,14 +1877,14 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
     - Same but for continued vote/existence?
 - Pros and cons of each level. Summary is that it seems like there's more pros and no real cons on being a software project (long term). 
 
-## Next steps
+### Next steps
 
 - **TODO**: open an issue on jupyter/accessibility and use it as a RFD (request for discussion)/lazy voting and revisit in 2-4 weeks?
 - Isabela to follow up with Mike on asking the community for feedback on existing accessibility fixes.
 
-## 4.6.22
+## 4.6.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Frederic
 - Nick
@@ -1896,7 +1900,7 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
 - Pooja
 - Isabela
 
-## What are people working on?
+### What are people working on?
 
 - Preston
     - Contributing guide questions https://github.com/jupyter/accessibility/issues/47
@@ -1927,21 +1931,21 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
     - tag people not necessarily accessibility involved if they know what's up
     - ask it in jupyterlab 
 
-## Next steps
+### Next steps
 
 - Follow up on accessibility fixes survey/feedback request (Isabela to Mike)
 - Follow up with Tania about last meeting's governance discussion (Isabela to Tania)
 - Three options for governance next steps and have people involved come to consensus (Isabela to create and tag people)
 
-## 4.20.22
+## 4.20.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Gabriel F.
 - Nick
 - Isabela
 
-## What are people working on?
+### What are people working on?
 
 - Please vote on [jupyter/accessibility's status in the new Jupyter governance](https://github.com/jupyter/accessibility/issues/81) by midnight wherever you are today!
 
@@ -1975,15 +1979,15 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
 - https://github.com/jupyter-server/jupyter_releaser
 - https://pv.github.io/numpy-bench/
 
-## 5.04.22
+## 5.04.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 
 - Martha
 - Isabela
 - Gabriel
 
-## What are people working on?
+### What are people working on?
 
 - Isabela
     - Governance follow up. We voted at [jupyter/accessibility #81](https://github.com/jupyter/accessibility/issues/81). Isabela needs to know how to move this forward.
@@ -1991,18 +1995,18 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
         - Feedback: documentation is the most valuable thing! 
         - Mentioned links: [Quansight-Labs/jupyter-a11y-mgmt #95 Scoping automated testing comment](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/95#issuecomment-1112427588) and [jupyter/accessibility #74 past draft PR for axe-core testing](https://github.com/jupyter/accessibility/pull/74).
 
-## Next steps
+### Next steps
 
 - The dream: updated galata documentation.😊
 - Follow up about governance status (Isabela)
 
-## 5.18.22
+## 5.18.22 Meeting Minutes 
 
-## Attendees
+### Attendees
 - Isabela
 - Martha
 
-## What are people working on?
+### What are people working on?
 - jupyter/accessibility is on its way to Subproject status! 🎉 PR is being voted on on [jupyter/governance #129](https://github.com/jupyter/governance/pull/129)
 - jupyter/accessibility automated testing has been updated! Changes are still being made, but there's a lot to show.
     - [jupyter/accessibility #83 Axe Gitpod JupyterLab](https://github.com/jupyter/accessibility/pull/83)


### PR DESCRIPTION
(And fix the last year of notes' formatting.)

I didn't expect to find formatting issues going so far back, so the list of files changed for got out of hand. The only new notes in need of review are 
- `2022-04-06.md`
- `2022-04-20.md`
- `2022-05-04.md`
- `2022-05-18.md`
- And the addition of those notes to `all-minutes.md`

All other files had their titles and heading numbers updated for correct note hierarchy.

Thanks in advance for any review! I'll merge this in a week if I don't hear anything by then. If you find a mistake past then, you can help fix it by opening an issue or PR and @'ing  me as needed. 🌻 