### PR TITLE
Add accessibility workshop to community docs

### DIFF
--- a/docs/community/meeting-minutes/2022-jupyter-accessibility-workshops/jupyter-accessibility-workshops.md
+++ b/docs/community/meeting-minutes/2022-jupyter-accessibility-workshops/jupyter-accessibility-workshops.md
@@ -1,0 +1,13 @@
+# Jupyter accessibility workshops
+
+Jupyter accessibility workshops were a series of [Jupyter community workshops](https://blog.jupyter.org/jupyter-community-workshops-cbd34ac82549) 
+in January and March 2022 focused on learning and practicing foundational 
+accessibility skills.
+
+Topics included 
+* Inclusive data representations (with [Frank Elavsky](https://www.frank.computer/)
+* Image descriptions for documentation
+* Accesibility and inclusive design (with [Eric Bailey](https://ericwbailey.design/))
+* And open source and manual testing
+
+All event resources, from workshop recordings to slides to notes, can be found on the [Jupyter accessibility workshop planning repo](https://github.com/Quansight-Labs/jupyter-accessibility-workshops#readme).


### PR DESCRIPTION
Remake of #93 after getting feedback.

This PR adds a description and links for the Jupyter accessibility workshops earlier this year as a part of the `notes` section in this repo.

Please let me know if you think the content needs fixing or belongs elsewhere. Thanks! 🌻