### PR TITLE
Add GitHub Action for Read the Docs previews

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,20 @@
+# .github/workflows/documentation-links.yaml
+
+name: Read the Docs Pull Request Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+    paths:
+      - 'docs/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/readthedocs-preview@main
+        with:
+          project-slug: "jupyter-accessibility"


### PR DESCRIPTION
This *should* add a GitHub action that automatically adds a docs preview link to the top comment of the PR. @trallard we can give this a shot instead of manually adding a link each time.

Note that this may not work until #106 is resolved.