### PR TITLE
Add CI workflow to check links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,14 @@
+name: Check Links
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+        with:
+          ignore_links: "https://github.com/issues"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: "https://github.com/issues"
+          ignore_links: "https://github.com/issues https://accessible.canada.ca/advancing-accessibility-standards-research/funding"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,8 +18,7 @@ In this repository, you will find the following:
 1. The [Binder configuration files](./.binder)
 2. [GitHub workflows and issues templates](./.github)
 3. [Sphinx documentation](./docs) for the accessibility project
-4. [Accessibility testing tools](./testing) for the user-facing core Jupyter software
-5. The [`ja11y` python module](./pa11y-jupyter)
+4. The [`ja11y` python module](./pa11y-jupyter)
 
 ## Code Map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ workflows.
 [doit]: https://pydoit.org/
 [binder]: https://mybinder.org
 [github actions]: https://github.com/features/actions
-[jupyter code of conduct]: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
+[jupyter code of conduct]: https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md
 [jupyter kernel messaging]: https://jupyter-client.readthedocs.io/en/stable/messaging.html
 [jupyter notebook format]: https://nbformat.readthedocs.io/en/stable/
 [miniforge]: https://github.com/conda-forge/miniforge/releases

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Anyone is welcome to attend, if they would like to discuss a topic or to listen 
 - **Where**: [`jovyan` Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
 - **What**: [current agenda](https://hackmd.io/WnaWXboXSiGoqWvev_fAvA). Feel free to add items to the upcoming event's agenda 🎉
 
-We also have a [public archive of all the previous meeting notes](https://readthedocs.org/projects/jupyter-accessibility/community/meeting-minutes/README).
+We also have a [public archive of all the previous meeting notes](https://jupyter-accessibility.readthedocs.io/en/latest/community/meeting-minutes/jupyterlab-accessibility-meetings/index.html).
 
 ## Links to accessibility standards and resources 🔗
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -57,4 +57,4 @@ meeting-minutes/2019-web4all-hackathon/hackathon-resources.md
 [jupyterhub-accessibility-issues]: https://github.com/jupyter/notebook/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility
 [jupyerlab-accessibility-issues]: https://github.com/jupyterhub/jupyterhub/issues?q=is%3Aopen+is%3Aissue+label%3Aaccessibility
 [notebook-accessibility-issues]: https://github.com/jupyter/notebook/issues?q=is%3Aopen+is%3Aissue+label%3Atag%3AAccessibility
-[jupyter-coc]: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
+[jupyter-coc]: https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2020-09-30.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2020-09-30.md
@@ -102,7 +102,7 @@ this meeting?
         ```
 
       - seems convoluted, can we just use
-        [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute)
+        [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
         (this is exactly what it's for)? [Opinions seem mixed](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/)
 
   - I need resources to finish hashing out the styling system for the

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2020-12-16.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2020-12-16.md
@@ -37,8 +37,7 @@ too)
     help and resources for screen reader users.
 - Adding CI or relevant accessibility tests to the JupyterLab
   contributing workflow ensure accessibility remains a priority - Referenced pydata-sphinx-theme [#292](https://github.com/pandas-dev/pydata-sphinx-theme/issues/292)
-  and https://github.com/pandas-dev/pydata-sphinx-theme/runs/1507397117?check_suite_focus=true - nteract has some kind of accessibility CI they use
-  (probably focused on react)
+  - nteract has some kind of accessibility CI they use (probably focused on react)
 
 #### JupyterLab Code Editor
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-07-28.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-07-28.md
@@ -17,7 +17,7 @@
 - Carlos
   - Curious about what is happening here!
   - We talked about testing some. Maybe recording and comparing videos might help for tracking interactions and avoiding accessibility regressions.
-  - Playwright? [blog post](https://www.yunier.dev/2021-03-13-accessibility-testing-with-playwright/)
+  - Playwright? [blog post](https://www.yunier.dev/post/2021/accessibility-testing-with-playwright/)
   - How can we support projects
 - Isabela
   - and Tony: Jupyter accessibility workshop. You can [track the work here](https://github.com/Quansight-Labs/jupyter-accessibility-workshops).

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-03.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-03.md
@@ -44,7 +44,7 @@
 
 - Isabela
   - Is anyone in contact/know status of Johan's work on the [CodeMirror6 migration](https://github.com/jupyterlab/jupyterlab/issues/10370#issuecomment-942048940)?
-    - Work is in progress ([there](https://github.com/JohanMabille/jupyterlab/tree/codemirror)). CodeMirror6 introduces a completly new API that brings some challenge. So Johan is focusing on having a first draft PR without carry too much about styles/modes and extensions. So people can start to test it and we will be able to evaluate what work is remaining (in particular if some CodeMirror extensions needs to be ported from 5 to 6).
+    - Work is in progress ([there](https://github.com/jupyterlab/jupyterlab/pull/11638)). CodeMirror6 introduces a completly new API that brings some challenge. So Johan is focusing on having a first draft PR without carry too much about styles/modes and extensions. So people can start to test it and we will be able to evaluate what work is remaining (in particular if some CodeMirror extensions needs to be ported from 5 to 6).
 - Frederic
   - I will test [Fast Design components](https://www.fast.design/) from Microsoft and report here.
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-17.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-11-17.md
@@ -32,7 +32,7 @@
   - Nick mentions wanting resources that help accessibility be a part of development as a focus of the repo. Should we be testing things like [Lorenz notebook](https://github.com/jupyterlab/jupyterlab-demo/blob/master/notebooks/Lorenz.ipynb) in accessibility tests?
 - Jason W
   - Resources for working on jupyterlab, retrolab, other packages simultaneously?
-    - [doit automation file](https://pydoit.org/task_args.html) https://github.com/jupyter/accessibility/blob/master/dodo.py
+    - [doit automation file](https://pydoit.org/task_args.html) https://github.com/jupyter/accessibility/blob/main/pa11y-jupyter/dodo.py
     - [Linking/Unlinking Packages to JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html#linking-unlinking-packages-to-jupyterlab)
     - [An example of testing such things in jupyter/accessibility](https://github.com/jupyter/accessibility/pull/35)
     - [Verdaccio](https://verdaccio.org/)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-12-01.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2021-12-01.md
@@ -24,7 +24,7 @@
 - Gabriel (Quansight Labs)
   - Automated accessibility testing
   - Quansight Labs [tracks my work on Jupyter](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/assigned/gabalafou) in a public GitHub repo
-  - Feel free to reach out to me on [gitter](https://gitter.im/gabalafou) or email me gfouasnon@quansight.com
+  - Feel free to reach out to me on [Gitter](https://app.gitter.im/) at @gabalafou or email me gfouasnon@quansight.com
 - Isabela
 
   - I'm back working on [#8832](https://github.com/jupyterlab/jupyterlab/issues/8832) as promised. I have some questions on search/filter boxes this week.

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-09-07.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/2022-09-07.md
@@ -11,7 +11,7 @@
 
 ### Agenda
 
-- How do we want to set up the council? Background: the [governance bootstrapping docs](https://jupyter.org/governance/bootstrapping_decision_making.html) don't account for the fact that we became a software project later and did not have existing steering council members to start our council process. We also need to have a council soon to nominate our representative to the new SSC soon.
+- How do we want to set up the council? Background: the [governance bootstrapping docs](https://jupyter.org/governance/decision_making.html) don't account for the fact that we became a software project later and did not have existing steering council members to start our council process. We also need to have a council soon to nominate our representative to the new SSC soon.
     - Some options to create the starter group:
         - Add who has already voted in our most recent votes as the starter group.
         - Add whoever is in the GitHub organization as the starter group.

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -1665,7 +1665,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 
 - Isabela
   - Is anyone in contact/know status of Johan's work on the [CodeMirror6 migration](https://github.com/jupyterlab/jupyterlab/issues/10370#issuecomment-942048940)?
-    - Work is in progress ([there](https://github.com/JohanMabille/jupyterlab/tree/codemirror)). CodeMirror6 introduces a completly new API that brings some challenge. So Johan is focusing on having a first draft PR without carry too much about styles/modes and extensions. So people can start to test it and we will be able to evaluate what work is remaining (in particular if some CodeMirror extensions needs to be ported from 5 to 6).
+    - Work is in progress ([there](https://github.com/jupyterlab/jupyterlab/pull/11638)). CodeMirror6 introduces a completly new API that brings some challenge. So Johan is focusing on having a first draft PR without carry too much about styles/modes and extensions. So people can start to test it and we will be able to evaluate what work is remaining (in particular if some CodeMirror extensions needs to be ported from 5 to 6).
 - Frederic
   - I will test [Fast Design components](https://www.fast.design/) from Microsoft and report here.
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -1709,7 +1709,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
   - Nick mentions wanting resources that help accessibility be a part of development as a focus of the repo. Should we be testing things like [Lorenz notebook](https://github.com/jupyterlab/jupyterlab-demo/blob/master/notebooks/Lorenz.ipynb) in accessibility tests?
 - Jason W
   - Resources for working on jupyterlab, retrolab, other packages simultaneously?
-    - [doit automation file](https://pydoit.org/task_args.html) https://github.com/jupyter/accessibility/blob/master/dodo.py
+    - [doit automation file](https://pydoit.org/task_args.html) https://github.com/jupyter/accessibility/blob/main/pa11y-jupyter/dodo.py
     - [Linking/Unlinking Packages to JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html#linking-unlinking-packages-to-jupyterlab)
     - [An example of testing such things in jupyter/accessibility](https://github.com/jupyter/accessibility/pull/35)
     - [Verdaccio](https://verdaccio.org/)

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -465,8 +465,7 @@ too)
     help and resources for screen reader users.
 - Adding CI or relevant accessibility tests to the JupyterLab
   contributing workflow ensure accessibility remains a priority - Referenced pydata-sphinx-theme [#292](https://github.com/pandas-dev/pydata-sphinx-theme/issues/292)
-  and https://github.com/pandas-dev/pydata-sphinx-theme/runs/1507397117?check_suite_focus=true - nteract has some kind of accessibility CI they use
-  (probably focused on react)
+  - nteract has some kind of accessibility CI they use (probably focused on react)
 
 #### JupyterLab Code Editor
 

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -1749,7 +1749,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Gabriel (Quansight Labs)
   - Automated accessibility testing
   - Quansight Labs [tracks my work on Jupyter](https://github.com/Quansight-Labs/jupyter-a11y-mgmt/issues/assigned/gabalafou) in a public GitHub repo
-  - Feel free to reach out to me on [gitter](https://gitter.im/gabalafou) or email me gfouasnon@quansight.com
+  - Feel free to reach out to me on [Gitter](https://app.gitter.im/) at @gabalafou or email me gfouasnon@quansight.com
 - Isabela
 
   - I'm back working on [#8832](https://github.com/jupyterlab/jupyterlab/issues/8832) as promised. I have some questions on search/filter boxes this week.

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -1407,7 +1407,7 @@ Priority issues: https://github.com/jupyterlab/jupyterlab/issues/9399
 - Carlos
   - Curious about what is happening here!
   - We talked about testing some. Maybe recording and comparing videos might help for tracking interactions and avoiding accessibility regressions.
-  - Playwright? [blog post](https://www.yunier.dev/2021-03-13-accessibility-testing-with-playwright/)
+  - Playwright? [blog post](https://www.yunier.dev/post/2021/accessibility-testing-with-playwright/)
   - How can we support projects
 - Isabela
   - and Tony: Jupyter accessibility workshop. You can [track the work here](https://github.com/Quansight-Labs/jupyter-accessibility-workshops).

--- a/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
+++ b/docs/community/meeting-minutes/jupyterlab-accessibility-meetings/all-minutes.md
@@ -106,7 +106,7 @@ this meeting?
         ```
 
       - seems convoluted, can we just use
-        [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute)
+        [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
         (this is exactly what it's for)? [Opinions seem mixed](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/)
 
   - I need resources to finish hashing out the styling system for the
@@ -2397,7 +2397,7 @@ Jupyter governance and jupyter/accessibility. A discussion around what's happeni
 
 ### Agenda
 
-- How do we want to set up the council? Background: the [governance bootstrapping docs](https://jupyter.org/governance/bootstrapping_decision_making.html) don't account for the fact that we became a software project later and did not have existing steering council members to start our council process. We also need to have a council soon to nominate our representative to the new SSC soon.
+- How do we want to set up the council? Background: the [governance bootstrapping docs](https://jupyter.org/governance/decision_making.html) don't account for the fact that we became a software project later and did not have existing steering council members to start our council process. We also need to have a council soon to nominate our representative to the new SSC soon.
     - Some options to create the starter group:
         - Add who has already voted in our most recent votes as the starter group.
         - Add whoever is in the GitHub organization as the starter group.

--- a/docs/contribute/guide.md
+++ b/docs/contribute/guide.md
@@ -111,7 +111,7 @@ _&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmr
 
 <!-- jupyter-wide -->
 
-[jupyter-coc]: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
+[jupyter-coc]: https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md
 
 <!-- hub -->
 
@@ -120,7 +120,7 @@ _&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmr
 <!-- general git links -->
 
 [link_git]: https://git-scm.com
-[link_github]: https://github.com/https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
+[link_github]: https://github.com/https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md
 [link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account
 [link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
 [markdown]: https://daringfireball.net/projects/markdown

--- a/docs/contribute/guide.md
+++ b/docs/contribute/guide.md
@@ -120,7 +120,7 @@ _&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmr
 <!-- general git links -->
 
 [link_git]: https://git-scm.com
-[link_github]: https://github.com/https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md
+[link_github]: https://github.com/jupyter/governance/blob/main/conduct/code_of_conduct.md
 [link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account
 [link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
 [markdown]: https://daringfireball.net/projects/markdown

--- a/docs/funding/czi-grant-completed.md
+++ b/docs/funding/czi-grant-completed.md
@@ -20,7 +20,7 @@ For the full scope of the two-year grant, all key items are listed on the [jupyt
 
 This roadmap's content is derived from:
 
-- [The original CZI grant proposal](https://github.com/jupyter/accessibility/blob/master/grant-applications/Inclusive_and_Accessible_Scientific_Computing_in_Jupyter_Ecosystem_SUBMITTED_PROPOSAL.pdf)
+- [The original CZI grant proposal](https://github.com/jupyter/accessibility/blob/main/docs/funding/Inclusive_and_Accessible_Scientific_Computing_in_Jupyter_Ecosystem_SUBMITTED_PROPOSAL.pdf)
 - The [jupyter-a11y-mgmt repository's planning issues](https://github.com/orgs/Quansight-Labs/projects/5/views/1)
 - The [JupyterLab accessibility project board](https://github.com/orgs/Quansight-Labs/projects/5/views/1)
 - Feedback from community members working on accessibility

--- a/pa11y-jupyter/README.md
+++ b/pa11y-jupyter/README.md
@@ -9,7 +9,7 @@ This folder contains:
 
 ## Future Goals
 
-- extract _tasks_ from [`dodo.py`](../dodo.py) into more configurable, reusable
+- extract _tasks_ from [`dodo.py`](./dodo.py) into more configurable, reusable
   components in this folder
 
 - create macros for `pa11y` [actions] for common Jupyter tasks


### PR DESCRIPTION
The link to the meeting notes seems to be broken at the moment: https://readthedocs.org/projects/jupyter-accessibility/community/meeting-minutes/README

![image](https://user-images.githubusercontent.com/591645/219336639-f62179b0-9d76-4d56-b993-875c1058f956.png)

This PR adds a GitHub Action workflow to help catch broken links: https://github.com/jupyterlab/maintainer-tools#check-links