### PR TITLE
Add Working group link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 🔔 Looking for [accessibility docs?](https://jupyter-accessibility.readthedocs.io/en/latest/accessibility-docs.html)
 
 Welcome to the GitHub repository for the [Jupyter](https://jupyter.org/) Accessibility Project.
-This [working group](https://jupyter.org/governance/standing_committees_and_working_groups.html) was formed in early 2019. Its goal is to gather stakeholders interested in working to make Jupyter's
+This [software subproject](https://jupyter.org/governance/software_subprojects.html) was formed in early 2019. Its goal is to gather stakeholders interested in working to make Jupyter's
 core user-facing software and related tooling accessible.
 
 These core user-facing software include:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 🔔 Looking for [accessibility docs?](https://jupyter-accessibility.readthedocs.io/en/latest/accessibility-docs.html)
 
 Welcome to the GitHub repository for the [Jupyter](https://jupyter.org/) Accessibility Project.
-This group was formed in early 2019. Its goal is to gather stakeholders interested in working to make Jupyter's
+This [working group](https://jupyter.org/governance/standing_committees_and_working_groups.html) was formed in early 2019. Its goal is to gather stakeholders interested in working to make Jupyter's
 core user-facing software and related tooling accessible.
 
 These core user-facing software include:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 🔔 Looking for [accessibility docs?](accessibility-docs)
 
-Welcome to the Team Compass for the Jupyter Accessibility project.
+Welcome to the Team Compass for the Jupyter Accessibility [working group](https://jupyter.org/governance/standing_committees_and_working_groups.html).
 
 This group was formed in early 2019.
 Its goal is to gather stakeholders interested in working to make Jupyter's

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 
 🔔 Looking for [accessibility docs?](accessibility-docs)
 
-Welcome to the Team Compass for the Jupyter Accessibility [working group](https://jupyter.org/governance/standing_committees_and_working_groups.html).
+Welcome to the Team Compass for the Jupyter Accessibility [software subproject](https://jupyter.org/governance/software_subprojects.html).
 
-This group was formed in early 2019.
+This subproject was formed in early 2019.
 Its goal is to gather stakeholders interested in working to make Jupyter's
 core user-facing software and related tooling accessible.
 


### PR DESCRIPTION
Is the accessibility group a working group? If so, let's simply link to the the meaning of a working-group in the jupyter context.

It's unclear to me whether Accessibility is a working group, a project or something else. With an answer, I will update this PR appropriately


<!-- readthedocs-preview jupyter-accessibility start -->
----
:books: Documentation preview :books:: https://jupyter-accessibility--128.org.readthedocs.build/en/128/

<!-- readthedocs-preview jupyter-accessibility end -->