### PR TITLE
Update Funding to include Notebooks For All (STScI) project

### DIFF
--- a/docs/funding/index.md
+++ b/docs/funding/index.md
@@ -20,4 +20,8 @@ This section lists past and ongoing funding for Jupyter Accessibility.
   - Cycle 4 - awarded to [Quansight Labs](https://labs.quansight.org/)
   - 2021-2023
   - [Submitted proposal](https://github.com/jupyter/accessibility/blob/1e048c086782cb10848292c4befbe09019853f96/docs/funding/Inclusive_and_Accessible_Scientific_Computing_in_Jupyter_Ecosystem_SUBMITTED_PROPOSAL.pdf) and [corresponding execution roadmap](czi-grant-roadmap.md)
+* - [Astronomy Notebooks For All - Space Telescope Science Institute (STScI)](https://github.com/Iota-School/notebooks-for-all#astronomy-notebooks-for-all)
+  - Internal grant at STScI
+  - 2022-2023
+  - [Submitted proposal](astronomy-notebooks-for-all.md) (minus personal information)
 ```

--- a/docs/funding/index.md
+++ b/docs/funding/index.md
@@ -23,5 +23,5 @@ This section lists past and ongoing funding for Jupyter Accessibility.
 * - [Astronomy Notebooks For All - Space Telescope Science Institute (STScI)](https://github.com/Iota-School/notebooks-for-all#astronomy-notebooks-for-all)
   - Internal grant at STScI
   - 2022-2023
-  - [Submitted proposal](astronomy-notebooks-for-all.md) (minus personal information)
+  - [Submitted proposal](https://github.com/Iota-School/notebooks-for-all/blob/main/resources/proposal-astronomy-notebooks-for-all.md) (minus personal information)
 ```

--- a/docs/funding/index.md
+++ b/docs/funding/index.md
@@ -23,5 +23,5 @@ This section lists past and ongoing funding for Jupyter Accessibility.
 * - [Astronomy Notebooks For All - Space Telescope Science Institute (STScI)](https://github.com/Iota-School/notebooks-for-all#astronomy-notebooks-for-all)
   - Internal grant at STScI
   - 2022-2023
-  - [Submitted proposal](https://github.com/Iota-School/notebooks-for-all/blob/main/resources/proposal-astronomy-notebooks-for-all.md) (minus personal information)
+  - [Submitted proposal](https://github.com/Iota-School/notebooks-for-all/blob/0c06d4fb037544fa96d3f90a1bb6efe7570a59a8/resources/proposal-astronomy-notebooks-for-all.md) (minus personal information)
 ```


### PR DESCRIPTION
To keep the Funding information of the docs as accurate as I can, I'd like to add a section to the table that notes and links to the full proposal for the [Astronomy Notebooks For All (Space Telescope Science Institute) project](https://github.com/Iota-School/notebooks-for-all#astronomy-notebooks-for-all).

This PR:
- Adds a section to the Funding table in the docs that includes the project
- Links out to the full proposal in the project repo

Please let me know if you have any questions or I can help make review easier. Thank you! 🌻 

<!-- readthedocs-preview jupyter-accessibility start -->
----
:books: Documentation preview :books:: https://jupyter-accessibility--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview jupyter-accessibility end -->