### PR TITLE
Add subproject SSC representative term length to documentation

### DIFF
--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -1,0 +1,16 @@
+# Jupyter Accessibility Governance
+
+Jupyter Accessibility is a [Project Jupyter Software Subproject](https://jupyter.org/governance/list_of_subprojects.html). 
+
+The [jupyter/accessibility](https://github.com/jupyter/accessibility) repository serves as our project's team compass, our central location for effort coordination, updates, and governance.
+
+## Subproject-specific governance
+
+The Jupyter Accessibility subproject follows the [Project Jupyter Software Subproject documentation](https://jupyter.org/governance/software_subprojects.html). Additional aspects of governance left to our subproject's own discretion are listed here.
+
+### Software Steering Council representative
+
+As a Software Subproject, the Jupyter Accessibility council elect one council member to be the project's representative to the [Project Jupyter Software Steering Council (SSC)](https://jupyter.org/governance/software_steering_council.html).
+
+- The term length for a Jupyter Accessibility SSC representative is one year. Elections are to be run within the council annually.
+- There is no cap on number of terms served by a Jupyter Accessibility SSC representative. There is no limit on consecutive terms served.

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -10,7 +10,7 @@ The Jupyter Accessibility subproject follows the [Project Jupyter Software Subpr
 
 ### Software Steering Council representative
 
-As a Software Subproject, the Jupyter Accessibility council elect one council member to be the project's representative to the [Project Jupyter Software Steering Council (SSC)](https://jupyter.org/governance/software_steering_council.html).
+As a Software Subproject, the Jupyter Accessibility council elects one council member to be the project's representative to the [Project Jupyter Software Steering Council (SSC)](https://jupyter.org/governance/software_steering_council.html).
 
 - The term length for a Jupyter Accessibility SSC representative is one year. Elections are to be run within the council annually.
 - There is no cap on number of terms served by a Jupyter Accessibility SSC representative. There is no limit on consecutive terms served.

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -1,8 +1,8 @@
 # Community Calls and Events
 
 ```{note}
-The Jupyter Accessibility project was recently converted into an [official Jupyter Software Subproject](https://jupyter.org/governance/software_subprojects.html).
-We are currently working on our governance and decision making, please bear with us while we get this sorted.
+The Jupyter Accessibility project was recently converted into an official Jupyter Software Subproject.
+Learn more on [our governance documentation]](governance.md)
 ```
 
 ## Get Connected with the Community

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -2,7 +2,7 @@
 
 ```{note}
 The Jupyter Accessibility project was recently converted into an official Jupyter Software Subproject.
-Learn more on [our governance documentation]](governance.md)
+Learn more on [our governance documentation](governance.md)
 ```
 
 ## Get Connected with the Community


### PR DESCRIPTION
Fixes #138

As the Jupyter Accessibility council voted to have a one-year term length for our SSC representative, the result needs to be represented somewhere. I am not aware of any preexisting governance documentation for this project, so I created a page for this purpose. This PR includes

- A new governance page in `governance.md` that briefly outlines our subproject status and the term length we voted on.
- An amendment to the Community section `index.md`'s note that references our status as a subproject. This note now points to `governance.md`

I'll admit I'm not very familiar with Jupyter Book and the docs structure we have now, so I expect to need to update this PR as I find errors. If you catch them before I do, feel free to point them out along with any other review. Thank you in advance!

<!-- readthedocs-preview jupyter-accessibility start -->
----
:books: Documentation preview :books:: https://jupyter-accessibility--140.org.readthedocs.build/en/140/

<!-- readthedocs-preview jupyter-accessibility end -->